### PR TITLE
Version 1.0.2 2021-11-04

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,6 @@
 /.scrutinizer.yml           export-ignore
 /infection.json.dist        export-ignore
 /phpcs.xml.dist             export-ignore
-/phpstan.xml.dist           export-ignore
+/phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
 /psalm.xml.dist             export-ignore

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 
 ## Listado de cambios
 
+### Version 1.0.2 2021-11-04
+
+- Las reglas del SAT cambiaron y la prueba de aceptación antes devolvía el estado "Cancelable sin aceptación"
+  y ahora devuelve el estado "Cancelable con aceptación".
+- Se corrige el nombre del archivo de configuración de PHPStan para ser excluido del paquete de distribución.
+
 ### Version 1.0.1 2021-09-03
 
 - La versión menor de PHP es 7.3.

--- a/src/ComplianceTester/ComplianceTester.php
+++ b/src/ComplianceTester/ComplianceTester.php
@@ -71,8 +71,8 @@ class ComplianceTester
         if (! $response->document()->isActive()) {
             throw new RuntimeException('It was expected CFDI status active: active');
         }
-        if (! $response->cancellable()->isCancellableByDirectCall()) {
-            throw new RuntimeException('It was expected CFDI status cancellable: directMethod');
+        if (! $response->cancellable()->isCancellableByApproval()) {
+            throw new RuntimeException('It was expected CFDI status cancellable: by approval');
         }
         if (! $response->cancellation()->isUndefined()) {
             throw new RuntimeException('It was expected CFDI status cancellation: undefined');


### PR DESCRIPTION
- Las reglas del SAT cambiaron y la prueba de aceptación antes devolvía el estado "Cancelable sin aceptación" y ahora devuelve el estado "Cancelable con aceptación".
- Se corrige el nombre del archivo de configuración de PHPStan para ser excluido del paquete de distribución.
