### PR TITLE
Mantenimiento 2025-09-26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,18 +94,18 @@ jobs:
         run: phpstan analyse --no-progress --verbose
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           extensions: soap
           coverage: none
           tools: composer:v2

--- a/.github/workflows/sonarqube-cloud.yml
+++ b/.github/workflows/sonarqube-cloud.yml
@@ -28,6 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
+          extensions: soap
           coverage: xdebug
           tools: composer:v2
       - name: Get composer cache directory

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.86.0" installed="3.86.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.13.2" installed="3.13.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.13.2" installed="3.13.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^2.1.22" installed="2.1.22" location="./tools/phpstan" copy="false"/>
-  <phar name="infection" version="^0.31.1" installed="0.31.2" location="./tools/infection" copy="false"/>
-  <phar name="composer-normalize" version="^2.47.0" installed="2.47.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.88.2" installed="3.88.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^4.0.0" installed="4.0.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.0" installed="4.0.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.29" installed="2.1.29" location="./tools/phpstan" copy="false"/>
+  <phar name="infection" version="^0.31.2" installed="0.31.2" location="./tools/infection" copy="false"/>
+  <phar name="composer-normalize" version="^2.48.2" installed="2.48.2" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,9 +15,10 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP82Migration:risky' => true,
-        '@PHP82Migration' => true,
+        '@PHP8x2Migration:risky' => true,
+        '@PHP8x2Migration' => true,
         // symfony
+        'array_indentation' => true,
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
@@ -37,6 +38,7 @@ return (new PhpCsFixer\Config())
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
         'fully_qualified_strict_types' => true,
+        'global_namespace_import' => ['import_classes' => true],
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,

--- a/README.md
+++ b/README.md
@@ -339,6 +339,6 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/sat-estado-cfdi/build.yml?branch=main&logo=github-actions
 [badge-reliability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_sat-estado-cfdi&metric=reliability_rating
 [badge-maintainability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_sat-estado-cfdi&metric=sqale_rating
-[badge-coverage]: https://img.shields.io/sonar/coverage/phpcfdi_sat-estado-cfdi/main?logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io
-[badge-violations]: https://img.shields.io/sonar/violations/phpcfdi_sat-estado-cfdi/main?format=long&logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io
+[badge-coverage]: https://img.shields.io/sonar/coverage/phpcfdi_sat-estado-cfdi/main?logo=sonarqubecloud&server=https%3A%2F%2Fsonarcloud.io
+[badge-violations]: https://img.shields.io/sonar/violations/phpcfdi_sat-estado-cfdi/main?format=long&logo=sonarqubecloud&server=https%3A%2F%2Fsonarcloud.io
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/sat-estado-cfdi?logo=packagist

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ No ha sido necesario liberar una nueva versión debido a que estos cambios no af
 - Se agregan las reglas `array_indentation` y `global_namespace_import` a *PHPCSFixer*.
 - Se actualizan las herramientas de desarrollo.
 - En el flujo de trabajo `build` se usa la variable `matrix.php-version` en singular.
+- Se agrega la extensión SOAP al flujo de trabajo de integración con SonarQube Cloud.
+- Se actualiza a la versión 6 de la acción `SonarSource/sonarqube-scan-action`.
 
 ### Mantenimiento 2025-08-21
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,16 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
 
+### Mantenimiento 2025-09-26
+
+No ha sido necesario liberar una nueva versión debido a que estos cambios no afectan el código ejecutable.
+
+- Se corrigen las insignias relacionadas a SonarQube Cloud.
+- Se actualizan las reglas de *PHPCSFixer* a la versión 3.88.
+- Se agregan las reglas `array_indentation` y `global_namespace_import` a *PHPCSFixer*.
+- Se actualizan las herramientas de desarrollo.
+- En el flujo de trabajo `build` se usa la variable `matrix.php-version` en singular.
+
 ### Mantenimiento 2025-08-21
 
 No ha sido necesario liberar una nueva versión debido a que estos cambios no afectan el código ejecutable.

--- a/src/Utils/ConsumerClientResponse.php
+++ b/src/Utils/ConsumerClientResponse.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\SatEstadoCfdi\Utils;
 
 use PhpCfdi\SatEstadoCfdi\Contracts\ConsumerClientResponseInterface;
+use Traversable;
 
 /**
  * This is a generic implementation of ConsumerClientResponseInterface
@@ -22,7 +23,7 @@ final readonly class ConsumerClientResponse implements ConsumerClientResponseInt
     {
         if (is_array($values)) {
             $values = (object) $values;
-        } elseif ($values instanceof \Traversable) {
+        } elseif ($values instanceof Traversable) {
             $values = (object) iterator_to_array($values);
         }
         if (! is_object($values)) {


### PR DESCRIPTION
- Se corrigen las insignias relacionadas a SonarQube Cloud.
- Se actualizan las reglas de *PHPCSFixer* a la versión 3.88.
- Se agregan las reglas `array_indentation` y `global_namespace_import` a *PHPCSFixer*.
- Se actualizan las herramientas de desarrollo.
- En el flujo de trabajo `build` se usa la variable `matrix.php-version` en singular.
- Se agrega la extensión SOAP al flujo de trabajo de integración con SonarQube Cloud.
- Se actualiza a la versión 6 de la acción `SonarSource/sonarqube-scan-action`.
